### PR TITLE
feat: Add rails 6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+garlic.rb
+garlic
+nbproject
+rdoc
+gemfiles/*.lock
+log/*
+.idea/
+*.sublime*

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This is a fake rails dependency to get around packages that pull in rails when t
 To use put this in your gemfile
 
 ```ruby
-gem 'rails', '~> 5.2', github: 'NetsoftHoldings/fakerails'
+gem 'rails', '~> 6.0.4', github: 'NetsoftHoldings/fakerails'
 ```
 
 Then add in the rest of your rails dependencies you need
 
 ```ruby
-rails_version='=5.2.6'
+rails_version='=6.0.4'
 [
   'activesupport',
   'actionpack',

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -3,17 +3,17 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "rails"
-  s.version     = '5.2.6'
+  s.version     = '6.0.4'
   s.summary     = "Fake rails dependency so you can pull in JUST what you need."
   s.description = "Fake rails dependency so you can pull in just what you need."
 
-  s.required_ruby_version     = ">= 2.2.2"
+  s.required_ruby_version     = ">= 2.5.0"
   s.required_rubygems_version = ">= 1.8.11"
 
   s.files = ["README.md"]
 
   s.author = "Edward Rudd"
 
-  s.add_dependency "bundler",         ">= 1.3.0"
+  s.add_dependency "bundler"
   s.add_dependency "sprockets-rails", ">= 2.0.0"
 end


### PR DESCRIPTION
## Change description

Allow Rails < 6.1

Tests are passing with deprecations we need to fix before moving to 6.1

```bash
Testing against rails 6.0.4.7
DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.1. (called from block in <top (required)> at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/test_helper.rb:118)
DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.1. (called from block in <top (required)> at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/test_helper.rb:119)
DEPRECATION WARNING: Using a dynamic :controller segment in a route is deprecated and will be removed in Rails 6.1. (called from block in <top (required)> at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/test_helper.rb:120)
DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.1. (called from block in <top (required)> at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/test_helper.rb:120)
Could not load Authorization::DevelopmentSupport::Analyzer.  Disabling AuthorizationRulesAnalyzerTest.
DEPRECATION WARNING: `.represent_boolean_as_integer=` is now always true, so setting this is deprecated and will be removed in Rails 6.1. (called from <top (required)> at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/model_test.rb:4)
Run options: --seed 63052

# Running:

........................./Users/felipemaier/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.4.7/lib/active_record/sanitization.rb:133: warning: too many arguments for format string
...........(eval):2: warning: unused literal ignored
................/Users/felipemaier/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.4.7/lib/active_record/sanitization.rb:133: warning: too many arguments for format string
.../Users/felipemaier/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.4.7/lib/active_record/sanitization.rb:133: warning: too many arguments for format string
/Users/felipemaier/.rvm/gems/ruby-2.5.5/gems/activerecord-6.0.4.7/lib/active_record/sanitization.rb:133: warning: too many arguments for format string
............DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead) (called from block in test_model_security_with_update_attrbributes at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/model_test.rb:1743)
...DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead) (called from block in test_model_security_write_not_allowed_no_privilege at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/model_test.rb:1526)
..(eval):2: warning: unused literal ignored
....DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead) (called from test_model_security_with_assoc at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/model_test.rb:1708)
...DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead) (called from block in test_model_security_write_not_allowed_wrong_attribute_value at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/model_test.rb:1556)
DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead) (called from test_model_security_write_not_allowed_wrong_attribute_value at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/model_test.rb:1559)
DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead) (called from block in test_model_security_write_not_allowed_wrong_attribute_value at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/model_test.rb:1562)
....DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead) (called from test_model_security_write_allowed at /Users/felipemaier/Documents/Hubstaff/declarative_authorization/test/model_test.rb:1496)
......................................................................................................
Finished in 1.266143s, 146.1130 runs/s, 314.3405 assertions/s.
185 runs, 398 assertions, 0 failures, 0 errors, 0 skips
```

### Security

- [ ] Security impact of change has been considered
